### PR TITLE
Undefined method index for downstream symbol

### DIFF
--- a/downstream.gemspec
+++ b/downstream.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.version = Downstream::VERSION
   spec.authors = ["merkushin.m.s@gmail.com", "dementiev.vm@gmail.com"]
   spec.summary = "Straightforward way to implement communication between Rails Engines using the Publish-Subscribe pattern"
-  spec.homepage = "https://github.com/bibendi/downstream"
+  spec.homepage = "https://github.com/palkan/downstream"
   spec.license = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'

--- a/downstream.gemspec
+++ b/downstream.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "debug", "~> 1.3"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-rails", "~> 5.0"
+  spec.add_development_dependency "rspec-rails", "~> 6.0"
   spec.add_development_dependency "sqlite3", "~> 1.4"
   spec.add_development_dependency "standard", "~> 1.3"
 end

--- a/lib/downstream/event.rb
+++ b/lib/downstream/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-GlobalID::Locator.use :downstream do |gid|
+GlobalID::Locator.use "downstream" do |gid|
   params = gid.params.each_with_object({}) do |(key, value), memo|
     memo[key.to_sym] = if value.is_a?(String) && value.start_with?("gid://")
       GlobalID::Locator.locate(value)
@@ -102,7 +102,7 @@ module Downstream
         end
       end
 
-      super(new_data.merge!(app: :downstream))
+      super(new_data.merge!(app: "downstream"))
     end
 
     alias_method :to_gid, :to_global_id


### PR DESCRIPTION
# Context

Currently 8 tests are failing when calling to_global_id as the app name is using a symbol instead of a string.
The `hostname=` method in the URI gem check if the app is an ipv6 address by calling `index(':')` on the symbol.
https://github.com/ruby/uri/blob/a0425d965940c670b942fcf1e1645c8a573e2698/lib/uri/generic.rb#L672

Stacktrace
```
NoMethodError (undefined method `index' for :downstream:Symbol):
  
uri (0.13.0) lib/uri/generic.rb:672:in `hostname='
uri (0.13.0) lib/uri/generic.rb:190:in `initialize'
uri (0.13.0) lib/uri/generic.rb:136:in `new'
uri (0.13.0) lib/uri/generic.rb:136:in `build'
globalid (1.2.1) lib/global_id/uri/gid.rb:98:in `build'
globalid (1.2.1) lib/global_id/uri/gid.rb:73:in `create'
globalid (1.2.1) lib/global_id/global_id.rb:14:in `create'
globalid (1.2.1) lib/global_id/identification.rb:38:in `to_global_id'
downstream (1.4.0) lib/downstream/event.rb:105:in `to_global_id'
```

## Related tickets
Not applicable


# What's inside
- changed the GlobalID app locator from `:downstream` to `"downstream"` which fixes the described issue above and makes all the test pass again.
- bumped rspec-rails dependancy from 5.0 to 6.0 to fix a deprecation warning `DEPRECATION WARNING: TestFixtures.fixture_path= is deprecated and will be removed in Rails 7.2. Use .fixture_paths= instead. (called from <top (required)> at downstream/spec/requests/server_timing_spec.rb:16)`.
- updated the gemspec homepage url to reference this repository

# Checklist:

- [X] I have added tests
- [X] I have made corresponding changes to the documentation
