### PR TITLE
Use after_initialize instead of to_prepare to prevent subscribing multiple times to events in development environment

### DIFF
--- a/lib/downstream/engine.rb
+++ b/lib/downstream/engine.rb
@@ -6,7 +6,7 @@ module Downstream
   class Engine < ::Rails::Engine
     config.downstream = Downstream.config
 
-    config.to_prepare do
+    config.after_initialize do
       ActiveSupport.run_load_hooks("downstream-events", Downstream)
     end
   end


### PR DESCRIPTION
# Context
The current config uses `.to_prepare` which is run after every code reload in development. This is annoying as subscribers get subscribed multiple times to the save event. 

One can easily reproduce the problem in development when using the rails console.
Call `reload!` from the console and publish an event. After reloading once, the subscriber is executed 3 times.

## Related tickets
I think this also addresses issue https://github.com/palkan/downstream/issues/6

# What's inside
Replace `.to_prepare` with `.after_initialize`

# Checklist:
- [ ] I have added tests
- [ ] I have made corresponding changes to the documentation

I had a look to create a failing test, but the current tests don't test the `ActiveSupport.on_load("downstream-events")` initializer and I'm unsure how to add it.