### PR TITLE
v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0 # Fetch current tag as annotated. See https://github.com/actions/checkout/issues/290
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4
       - name: Configure RubyGems Credentials
         uses: rubygems/configure-rubygems-credentials@main
       - name: Publish to RubyGems

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,23 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2"]
+        ruby: ["3.4"]
         gemfile: [
-          "gemfiles/rails71.gemfile",
+          "gemfiles/rails8.gemfile",
         ]
         include:
         - ruby: "3.4"
           gemfile: "gemfiles/railsmaster.gemfile"
         - ruby: "3.3"
           gemfile: "gemfiles/rails8.gemfile"
+        - ruby: "3.2"
+          gemfile: "gemfiles/rails7.gemfile"
         - ruby: "3.1"
           gemfile: "gemfiles/rails7.gemfile"
-        - ruby: "3.0"
-          gemfile: "gemfiles/rails7.gemfile"
-        - ruby: "2.7"
-          gemfile: "gemfiles/rails6.gemfile"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install system deps
       run: |
         sudo apt-get update

--- a/.rubocop-md.yml
+++ b/.rubocop-md.yml
@@ -9,4 +9,8 @@ AllCops:
 
 Naming/FileName:
   Exclude:
-   - '**/*.md'
+    - '**/*.md'
+
+Lint/ConstantReassignment:
+  Exclude:
+    - '**/*.md'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
   DisplayCopNames: true
   SuggestExtensions: false
   NewCops: disable
+  TargetRubyVersion: 3.1
 
 Standard/BlockSingleLineBraces:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Added `Downstream::Event.define` to use Data-backed event payloads.
+
 ## 1.6.0 (2025-02-14)
 
 - Reset subscribers on code reloading to avoid double execution.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ Each event has predefined (_reserved_) fields:
 
 Events are stored in `app/events` folder.
 
+You can also define events using the Data-interface:
+
+```ruby
+ProfileCreated = Downstream::Event.define(:user)
+
+# or with an explicit identifier
+ProfileCreated = Downstream::Event.define(:user) do
+  self.identifier = "user.profile_created"
+end
+```
+
+Date-events provide the same interface as regular events but use Data classes for keeping event payloads (`event.data`) and are frozen (as well as their derivatives, such as `event.to_h`).
+
+> [!NOTE]
+> Data-events are only available in Ruby 3.2+.
+
 ### Publish events
 
 To publish an event you must first create an instance of the event class and call `Downstream.publish` method:

--- a/downstream.gemspec
+++ b/downstream.gemspec
@@ -29,11 +29,11 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob("lib/**/*") + %w[LICENSE.txt README.md]
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.add_dependency "after_commit_everywhere", "~> 1.0"
   spec.add_dependency "globalid", "~> 1.0"
-  spec.add_dependency "rails", ">= 6"
+  spec.add_dependency "rails", ">= 7"
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "combustion", "~> 1.3"

--- a/gemfiles/rails6.gemfile
+++ b/gemfiles/rails6.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'sqlite3', '~> 1.4.0'
-gem 'rails', '~> 6.0'
-
-gemspec path: '..'

--- a/gemfiles/resmaster.gemfile
+++ b/gemfiles/resmaster.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'sqlite3', '~> 1.4'
-gem 'rails', '~> 7.0'
+gem 'sqlite3', '~> 2.0'
+gem 'rails', '~> 8.0'
 gem 'rails_event_store', github: 'RailsEventStore/rails_event_store'
 
 gemspec path: '..'

--- a/lib/downstream.rb
+++ b/lib/downstream.rb
@@ -8,6 +8,7 @@ require "after_commit_everywhere"
 
 require "downstream/config"
 require "downstream/event"
+require "downstream/data_event"
 require "downstream/pubsub_adapters/abstract_pubsub"
 require "downstream/subscriber_job"
 

--- a/lib/downstream/data_event.rb
+++ b/lib/downstream/data_event.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Downstream
+  class DataEvent < Event
+    class << self
+      attr_writer :data_class
+
+      def data_class
+        return @data_class if @data_class
+
+        @data_class = superclass.data_class
+      end
+
+      undef_method :attributes
+      undef_method :defined_attributes
+    end
+
+    def initialize(event_id: nil, **attrs)
+      @event_id = event_id || SecureRandom.hex(10)
+      @data = self.class.data_class.new(**attrs)
+      freeze
+    end
+
+    def to_h
+      {
+        type:,
+        event_id:,
+        data: data.to_h.freeze
+      }.freeze
+    end
+  end
+end

--- a/lib/downstream/engine.rb
+++ b/lib/downstream/engine.rb
@@ -6,6 +6,19 @@ module Downstream
   class Engine < ::Rails::Engine
     config.downstream = Downstream.config
 
+    ::GlobalID::Locator.use "downstream" do |gid|
+      params = gid.params.each_with_object({}) do |(key, value), memo|
+        memo[key.to_sym] = if value.is_a?(String) && value.start_with?("gid://")
+          GlobalID::Locator.locate(value)
+        else
+          value
+        end
+      end
+
+      gid.model_name.constantize
+        .new(event_id: gid.model_id, **params)
+    end
+
     config.to_prepare do
       Downstream.pubsub.reset
       ActiveSupport.run_load_hooks("downstream-events", Downstream)

--- a/lib/downstream/event.rb
+++ b/lib/downstream/event.rb
@@ -13,7 +13,7 @@ module Downstream
       def identifier
         return @identifier if instance_variable_defined?(:@identifier)
 
-        @identifier = name.underscore.tr("/", ".")
+        @identifier = name.underscore.tr("/", ".").gsub(/_event$/, "")
       end
 
       # define store readers

--- a/lib/downstream/rspec/have_published_event.rb
+++ b/lib/downstream/rspec/have_published_event.rb
@@ -74,7 +74,7 @@ module Downstream
     end
 
     def failure_message
-      (+"expected to publish #{event_class.identifier} event").tap do |msg|
+      "expected to publish #{event_class.identifier} event".tap do |msg|
         msg << " #{message_expectation_modifier}, but haven't published"
       end
     end

--- a/lib/downstream/subscriber.rb
+++ b/lib/downstream/subscriber.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Downstream
+  class Subscriber
+    class << self
+      # All public names are considered event handlers
+      # (same concept as action_names in controllers/mailers)
+      def event_names
+        @event_names ||= begin
+          # All public instance methods of this class, including ancestors
+          methods = (public_instance_methods(true) -
+            # Except for public instance methods of Base and its ancestors
+            Downstream.public_instance_methods(true) +
+            # Be sure to include shadowed public instance methods of this class
+            public_instance_methods(false)).uniq.map(&:to_s)
+          methods.to_set
+        end
+      end
+
+      # Downstream subscriber interface
+      def call(event)
+        new.process_event(event)
+      end
+    end
+
+    def process_event(event)
+      # TODO: callbacks? instrumentation?
+      # TODO: namespaced events?
+      public_send(event.type, event)
+    end
+  end
+end

--- a/spec/lib/data_event_spec.rb
+++ b/spec/lib/data_event_spec.rb
@@ -31,7 +31,7 @@ describe Downstream::Event, skip: !defined?(Data) do
 
     specify "inferred" do
       stub_const("Downstream::DataTestEvent", Downstream::Event.define(:user_id))
-      expect(Downstream::DataTestEvent.identifier).to eq "downstream.data_test_event"
+      expect(Downstream::DataTestEvent.identifier).to eq "downstream.data_test"
     end
   end
 

--- a/spec/lib/data_event_spec.rb
+++ b/spec/lib/data_event_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Downstream::Event, skip: !defined?(Data) do
+  let(:event_class) do
+    described_class.define(:user_id, :action_type) do
+      self.identifier = "test_event"
+    end
+  end
+
+  let(:event) { event_class.new(user_id: 1, action_type: "test") }
+
+  specify do
+    expect(event).to be_frozen
+    expect(event.data).to be_a(Data)
+
+    expect(event.user_id).to eq 1
+    expect(event.action_type).to eq "test"
+
+    expect(event.data.user_id).to eq 1
+    expect(event.data.action_type).to eq "test"
+
+    expect(event.event_id).not_to be_nil
+  end
+
+  describe ".identifier" do
+    specify "explicit" do
+      expect(event_class.identifier).to eq "test_event"
+    end
+
+    specify "inferred" do
+      stub_const("Downstream::DataTestEvent", Downstream::Event.define(:user_id))
+      expect(Downstream::DataTestEvent.identifier).to eq "downstream.data_test_event"
+    end
+  end
+
+  describe "#to_h" do
+    specify do
+      hevent = event.to_h
+      expect(hevent).to eq(
+        event_id: event.event_id,
+        data: {
+          user_id: 1,
+          action_type: "test"
+        },
+        type: "test_event"
+      )
+      expect(hevent).to be_frozen
+      expect(hevent[:data]).to be_frozen
+    end
+  end
+
+  specify "sets event_id if event_id is provided" do
+    event = event_class.new(event_id: "123", user_id: 22, action_type: "test")
+    expect(event.to_h).to eq(
+      event_id: "123",
+      data: {
+        user_id: 22,
+        action_type: "test"
+      },
+      type: "test_event"
+    )
+  end
+
+  specify "raises if unknown field is passed" do
+    expect { event_class.new(users_ids: [1]) }.to raise_error(
+      ArgumentError, /missing keywords: :user_id, :action_type/
+    )
+  end
+
+  specify "raises argument error if type attribute is defined" do
+    expect { described_class.define(:type) }.to raise_error(
+      ArgumentError, /type is reserved/
+    )
+  end
+
+  specify "raises argument error if event_id attribute is defined" do
+    expect { described_class.define(:event_id) }.to raise_error(
+      ArgumentError, /event_id is reserved/
+    )
+  end
+end

--- a/spec/lib/event_spec.rb
+++ b/spec/lib/event_spec.rb
@@ -19,7 +19,7 @@ describe Downstream::Event do
     end
 
     specify "inferred" do
-      expect(Downstream::AnotherTestEvent.identifier).to eq "downstream.another_test_event"
+      expect(Downstream::AnotherTestEvent.identifier).to eq "downstream.another_test"
     end
   end
 

--- a/spec/lib/rspec_matchers_spec.rb
+++ b/spec/lib/rspec_matchers_spec.rb
@@ -44,7 +44,7 @@ describe "RSpec matchers" do
         expect do
           expect { Downstream.publish event }
             .to have_published_event(Downstream::AnotherTestEvent)
-        end.to raise_error(/to publish downstream.another_test_event.+exactly once, but/)
+        end.to raise_error(/to publish downstream.another_test.+exactly once, but/)
       end
 
       specify "attributes don't match" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.after(:each) do
+    Downstream.pubsub.reset
     # Clear ActiveJob jobs
     ActiveJob::Base.queue_adapter.enqueued_jobs.clear
     ActiveJob::Base.queue_adapter.performed_jobs.clear


### PR DESCRIPTION
# Context

This PR tracks the changes for v2.

# What's inside

- [x] Ruby 3.1 and Rails 7 now required
- [x] Data-backed events (#11)
- [x] `Downstream::Subscriber` class

# Checklist:

- [x] I have added tests
- [x] I have made corresponding changes to the documentation
